### PR TITLE
Add Dockerfile and Marathon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,17 @@
 FROM python:2
 MAINTAINER André Roaldseth <andrer@vg.no>
 
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# libicu-dev is required for building PyICU with pip
+RUN apt-get update && apt-get install -y --force-yes python-numpy libicu-dev
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
+
 EXPOSE 5000
 
 CMD [ "python", "./app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3-onbuild
+MAINTAINER André Roaldseth <andrer@vg.no>
+
+EXPOSE 5000
+
+CMD [ "python", "./app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3-onbuild
+# Pip fails to install dependencies with python3
+FROM python:2
 MAINTAINER André Roaldseth <andrer@vg.no>
 
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get install -y --force-yes python-numpy libicu-dev
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r requirements.txt
 
+RUN polyglot download LANG:no
+
 COPY . /usr/src/app
 
 EXPOSE 5000


### PR DESCRIPTION
Add a Dockerfile to build a docker container.

Also includes a Marathon service descriptor file to run the docker container on Mesosphere.
